### PR TITLE
Reduce trailing space

### DIFF
--- a/classes/glift.php
+++ b/classes/glift.php
@@ -174,15 +174,18 @@ class Glift {
 		$html =
 			"\n\r<div id='$divId' style='$style'></div>".
 			"\n\r<script type='text/javascript'>".
-			"gliftWidget = glift.create($json);</script>\n\r<p>&nbsp;</p>\n\r".
-			"<div align ='center'><noscript>$noscript</noscript> ";
+			"gliftWidget = glift.create($json);</script>\n\r".
+			"<div align ='center'><noscript>$noscript</noscript>";
 
-			// add a hyperlink to download the SGF if appropriate
-			if ( $download && TRUE != $this->nolink )
-			$html .= 	"<a href='$download' download>$anchor</a>";
+			// add a hyperlink to download the SGF if appropriate and some
+			// whitespace.
+			if ( $download && TRUE != $this->nolink ) {
+				$html .= "\n\r<p></p>\n\r".
+					"<a href='$download' download>$anchor</a>";
+			}
 
-			// close the <div> tag and add some white space
-			$html .= "</div>\n\r<p>&nbsp;</p>";
+			// close the centering <div> tag
+			$html .= "</div>\n\r<p></p>";
 
 		return $html;
 	}

--- a/glift-go-game.php
+++ b/glift-go-game.php
@@ -2,7 +2,7 @@
 
 /*
 Plugin Name: Glift Go Game
-Version: 0.6.5
+Version: 0.6.6
 Plugin URI: https://gogameguru.com/glift/
 Description: Bring the board game Go (围棋 weiqi, 囲碁 igo or 바둑 baduk) to your WordPress site. Integrates the Glift JavaScript Go library with WordPress.
 Author: Go Game Guru
@@ -10,7 +10,7 @@ Author URI: https://gogameguru.com/
 License: MIT (X11)
 
 Glift Go Game WordPress Plugin
-Copyright (c) 2014, 2015 Go Game Guru
+Copyright (c) 2014-2016 Go Game Guru
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://gogameguru.com/support/
 Tags: go game, board games, baduk, igo, weiqi, 围棋, 囲碁, 바둑, Cờ vây, chess
 Requires at least: 2.5
 Tested up to: 4.5.2
-Stable tag: 0.6.5
+Stable tag: 0.6.6
 License: MIT (X11)
 License URI: http://opensource.org/licenses/MIT
 
@@ -59,6 +59,10 @@ Yes, if you previously used EidoGo for WordPress, you have two options:
 Yes, visit [gliftgo.com](http://www.gliftgo.com/ "Glift Go") for more information and sample code.
 
 == Changelog ==
+
+= 0.6.6 =
+
+* Fix - Reduce the trailing whitespace around the Glift instance.
 
 = 0.6.5 =
 * Feature - Upgrade Glift to 1.1.1


### PR DESCRIPTION
This reduces the trailing whitespace around the Glift instance by moving one of the `<p>`s if-condition for the download link.

FYI: I haven't tested this. I don't know how to locally test this plugin.